### PR TITLE
chore: update npm site

### DIFF
--- a/packages/quark-core/package.json
+++ b/packages/quark-core/package.json
@@ -39,9 +39,10 @@
     "rollup": "2.77.0",
     "rollup-plugin-filesize": " ^9.1.2"
   },
+  "homepage": "https://quark.hellobike.com",
   "repository": {
     "type": "git",
-    "url": "https://github.com/hellof2e/quark-design.git"
+    "url": "git@github.com:hellof2e/quark.git"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
修复 npm 的链接不对, 无法快速找到仓库, 每次来看进展, 从 npm 就找不到路.